### PR TITLE
[MNG-5813] pass debug-opts from mvnDebug to mvn script in the additio…

### DIFF
--- a/apache-maven/src/bin/mvn
+++ b/apache-maven/src/bin/mvn
@@ -235,6 +235,7 @@ export MAVEN_CMD_LINE_ARGS
 
 exec "$JAVACMD" \
   $MAVEN_OPTS \
+  $MAVEN_DEBUG_OPTS \
   -classpath "${M2_HOME}"/boot/plexus-classworlds-*.jar \
   "-Dclassworlds.conf=${M2_HOME}/bin/m2.conf" \
   "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \

--- a/apache-maven/src/bin/mvnDebug
+++ b/apache-maven/src/bin/mvnDebug
@@ -38,4 +38,4 @@ MAVEN_DEBUG_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,addre
 
 echo Preparing to Execute Maven in Debug Mode
 
-env MAVEN_OPTS="$MAVEN_OPTS $MAVEN_DEBUG_OPTS" $(dirname $0)/mvn "$@"
+env MAVEN_OPTS="$MAVEN_OPTS" MAVEN_DEBUG_OPTS="$MAVEN_DEBUG_OPTS" $(dirname $0)/mvn "$@"


### PR DESCRIPTION
…nal env-variable MAVEN_DEBUG_OPTS to not interfere with user-specified MAVEN_OPTS (e.g. when read from .mavenrc).

Fixed as suggested by Robert Patrick on the ML